### PR TITLE
[SMF-1458] add #delete, #read_multi, and #write_multi methods

### DIFF
--- a/lib/omnicache/store.rb
+++ b/lib/omnicache/store.rb
@@ -42,56 +42,69 @@ module OmniCache
     # Reads a value from the store
     # @param key [String | Symbol] The key to read
     def read(key)
-      key = key.to_s
-      entry = maybe_threadsafe do
-        entry = @is_lru ? @data.delete(key) : @data[key]
-        return nil if entry.nil?
-
-        if entry.expired?
-          @data.delete(key) unless @is_lru # we already deleted it if LRU
-          subtract_size(key, entry)
-          return nil
-        end
-
-        @data[key] = entry if @is_lru
-        entry
-      end
-
-      @serializer.load(entry.value)
+      maybe_threadsafe { get_value(key) }
     end
 
     alias [] read
     alias get read
 
-    def write(key, value, ttl_seconds: nil)
-      key = key.to_s
+    # Reads multiple values at once from the store
+    # @param keys [Array<String>] The keys to read
+    # @return [Hash] A hash mapping the keys provided to the values found
+    def read_multi(*keys)
       maybe_threadsafe do
-        if @is_lru || value.nil?
-          existing = @data.delete(key)
-          subtract_size(key, existing)
+        keys.each_with_object({}) do |key, results|
+          value = get_value(key)
+          if value
+            results[key] = value
+          end
         end
-
-        serialized_value = @serializer.dump(value)
-        return nil if serialized_value.nil?
-
-        entry = Entry.new(
-          serialized_value,
-          ttl_seconds: ttl_seconds || @default_ttl_seconds
-        )
-
-        @data[key] = entry
-        add_size(key, entry)
-
-        adjust_size if @is_lru
       end
-      value
+    end
+
+    def write(key, value, ttl_seconds: nil)
+      maybe_threadsafe do
+        delete_entry(key) if @is_lru || value.nil?
+        entry = create_entry(key, value, ttl_seconds)
+        if entry
+          value
+        end
+      end
     end
 
     alias []= write
     alias set write
 
+    # Writes multiple values at once to the store
+    # @param hash [Hash] A hash mapping keys to values to write
+    # @param ttl_seconds [Integer] TTL for the new entries, in seconds. Uses the default TTL if not provided.
+    # @return [Hash] A hash mapping the keys provided to the values written
+    def write_multi(hash, ttl_seconds: nil)
+      maybe_threadsafe do
+        hash.each_with_object({}) do |(key, value), results|
+          delete_entry(key) if @is_lru || value.nil?
+          entry = create_entry(key, value, ttl_seconds)
+          if entry
+            results[key] = value
+          end
+        end
+      end
+    end
+
     def fetch(key, ttl_seconds: nil)
       read(key) || write(key, yield, ttl_seconds: ttl_seconds)
+    end
+
+    # Deletes a value from the store
+    # @param key [String] The key to delete
+    # @return [Object|nil] The deleted value if it existed, nil otherwise
+    def delete(key)
+      maybe_threadsafe do
+        entry = delete_entry(key)
+        if entry
+          @serializer.load(entry.value)
+        end
+      end
     end
 
     def clear
@@ -161,6 +174,44 @@ module OmniCache
       else
         yield
       end
+    end
+
+    def get_value(key)
+      key = key.to_s
+      entry = @is_lru ? @data.delete(key) : @data[key]
+      return nil if entry.nil?
+
+      if entry.expired?
+        @data.delete(key) unless @is_lru # we already deleted it if LRU
+        subtract_size(key, entry)
+        return nil
+      end
+
+      @data[key] = entry if @is_lru
+      @serializer.load(entry.value)
+    end
+
+    def create_entry(key, value, ttl_seconds)
+      key = key.to_s
+      serialized_value = @serializer.dump(value)
+      return nil if serialized_value.nil?
+
+      entry = Entry.new(
+        serialized_value,
+        ttl_seconds: ttl_seconds || @default_ttl_seconds
+      )
+
+      @data[key] = entry
+      add_size(key, entry)
+      adjust_size if @is_lru
+      entry
+    end
+
+    def delete_entry(key)
+      key = key.to_s
+      entry = @data.delete(key)
+      subtract_size(key, entry)
+      entry
     end
   end
 end

--- a/spec/omnicache/store_spec.rb
+++ b/spec/omnicache/store_spec.rb
@@ -97,8 +97,8 @@ RSpec.describe OmniCache::Store do
       store.write("key1", values)
       store.write_multi({ "key2" => values })
       values << 4
-      expect(store.read("key1")).to eq([1, 2, 3, 4])
-      expect(store.read("key2")).to eq([1, 2, 3, 4])
+      expect(store.read("key1")).to be(values)
+      expect(store.read("key2")).to be(values)
     end
   end
 

--- a/spec/omnicache/store_spec.rb
+++ b/spec/omnicache/store_spec.rb
@@ -32,10 +32,19 @@ RSpec.describe OmniCache::Store do
       expect(store.read("key")).to eq("value")
     end
 
+    it "can store and retrieve multiple values at once" do
+      store.write_multi({ "key1" => "value1", "key2" => "value2" })
+      expect(store.read_multi("key1", "key2")).to eq("key1" => "value1", "key2" => "value2")
+    end
+
     it "coerces keys to strings" do
       store.write(123, "value")
       expect(store.read(123)).to eq("value")
       expect(store.read("123")).to eq("value")
+
+      store.write_multi({ 456 => "value" })
+      expect(store.read_multi(456)).to eq(456 => "value")
+      expect(store.read_multi("456")).to eq("456" => "value")
     end
 
     it "returns nil if the key does not exist" do
@@ -44,16 +53,38 @@ RSpec.describe OmniCache::Store do
 
     it "stores immutable values" do
       values = [1, 2, 3]
-      store.write("key", values)
+      store.write("key1", values)
+      store.write_multi({ "key2" => values })
       values << 4
-      expect(store.read("key")).to eq([1, 2, 3])
+      expect(store.read_multi("key1", "key2")).to eq("key1" => [1, 2, 3], "key2" => [1, 2, 3])
     end
 
     it "does not return a value that has expired" do
       store.write("key", "value", ttl_seconds: 10)
+      store.write_multi({ "key2" => "value2" }, ttl_seconds: 10)
       Timecop.freeze(Time.now + 20) do
         expect(store.read("key")).to be_nil
+        expect(store.read_multi("key2")).to eq({})
       end
+    end
+
+    it "can delete a value from the store" do
+      store.write("key", "value")
+      expect(store.delete("key")).to eq("value")
+      expect(store.read("key")).to be_nil
+    end
+
+    it "returns nil when deleting a non-existent key" do
+      expect(store.delete("key")).to be_nil
+    end
+
+    it "returns results for read_multi with the given keys" do
+      store.write_multi({ "key1" => "value1", "key2" => "value2" })
+      expect(store.read_multi(:key1, "key2")).to eq({ key1: "value1", "key2" => "value2" })
+    end
+
+    it "returns write_multi results with the given keys" do
+      expect(store.write_multi({ key1: "value1", "key2" => "value2" })).to eq({ key1: "value1", "key2" => "value2" })
     end
   end
 
@@ -63,79 +94,140 @@ RSpec.describe OmniCache::Store do
 
     it "uses that serializer" do
       values = [1, 2, 3]
-      store.write("key", values)
+      store.write("key1", values)
+      store.write_multi({ "key2" => values })
       values << 4
-      expect(store.read("key")).to eq([1, 2, 3, 4])
+      expect(store.read("key1")).to eq([1, 2, 3, 4])
+      expect(store.read("key2")).to eq([1, 2, 3, 4])
     end
   end
 
   context "with max_entries set" do
     let(:store) { described_class.new(max_entries: 2) }
 
-    it "evicts the least recently used entry when the size is exceeded" do
-      store.write("key1", "value1")
-      store.write("key2", "value2")
-      store.read("key1")
-      store.write("key3", "value3")
-
-      expect(store.size).to eq(2)
-      expect(store.read("key1")).to eq("value1")
-      expect(store.read("key3")).to eq("value3")
-      expect(store.read("key2")).to be_nil
-    end
-
-    it "removes expired entries first before evicting others" do
-      store.write("key1", "value1", ttl_seconds: 10)
-      store.write("key2", "value2")
-      store.read("key1")
-
-      Timecop.freeze(Time.now + 20) do
+    describe "using #read & #write" do
+      it "evicts the least recently used entry when the size is exceeded" do
+        store.write("key1", "value1")
+        store.write("key2", "value2")
+        store.read("key1")
         store.write("key3", "value3")
+
+        expect(store.size).to eq(2)
+        expect(store.read("key1")).to eq("value1")
+        expect(store.read("key3")).to eq("value3")
+        expect(store.read("key2")).to be_nil
       end
 
-      expect(store.size).to eq(2)
-      expect(store.read("key2")).to eq("value2")
-      expect(store.read("key3")).to eq("value3")
-      expect(store.read("key1")).to be_nil
+      it "removes expired entries first before evicting others" do
+        store.write("key1", "value1", ttl_seconds: 10)
+        store.write("key2", "value2")
+        store.read("key1")
+
+        Timecop.freeze(Time.now + 20) do
+          store.write("key3", "value3")
+        end
+
+        expect(store.size).to eq(2)
+        expect(store.read("key2")).to eq("value2")
+        expect(store.read("key3")).to eq("value3")
+        expect(store.read("key1")).to be_nil
+      end
+    end
+
+    describe "using #read_multi & #write_multi" do
+      it "evicts the least recently used entry when the size is exceeded" do
+        store.write_multi({ "key1" => "value1", "key2" => "value2" })
+        store.read_multi("key1")
+        store.write_multi({ "key3" => "value3" })
+
+        expect(store.size).to eq(2)
+        expect(store.read_multi("key1", "key2", "key3")).to eq({ "key1" => "value1", "key3" => "value3" })
+      end
+
+      it "removes expired entries first before evicting others" do
+        store.write_multi({ "key1" => "value1" }, ttl_seconds: 10)
+        store.write_multi({ "key2" => "value2" })
+        store.read_multi("key1")
+
+        Timecop.freeze(Time.now + 20) do
+          store.write_multi({ "key3" => "value3" })
+        end
+
+        expect(store.size).to eq(2)
+        expect(store.read_multi("key1", "key2", "key3")).to eq({ "key2" => "value2", "key3" => "value3" })
+      end
     end
   end
 
   context "with max_size_bytes set" do
     let(:store) { described_class.new(max_size_bytes: 20, serializer: string_serializer) }
 
-    it "evicts the least recently used entry when the size is exceeded" do
-      store.write("key1", "value1")
-      store.write("key2", "value2")
-      store.read("key1")
-      store.write("key3", "value3")
-
-      expect(store.size).to eq(2)
-      expect(store.current_size_bytes).to eq(20)
-      expect(store.read("key1")).to eq("value1")
-      expect(store.read("key3")).to eq("value3")
-      expect(store.read("key2")).to be_nil
-    end
-
-    it "removes expired entries first before evicting others" do
-      store.write("key1", "value1", ttl_seconds: 10)
-      store.write("key2", "value2")
-      store.read("key1")
-
-      Timecop.freeze(Time.now + 20) do
+    describe "using #read & #write" do
+      it "evicts the least recently used entry when the size is exceeded" do
+        store.write("key1", "value1")
+        store.write("key2", "value2")
+        store.read("key1")
         store.write("key3", "value3")
+
+        expect(store.size).to eq(2)
+        expect(store.current_size_bytes).to eq(20)
+        expect(store.read("key1")).to eq("value1")
+        expect(store.read("key3")).to eq("value3")
+        expect(store.read("key2")).to be_nil
       end
 
-      expect(store.size).to eq(2)
-      expect(store.current_size_bytes).to eq(20)
-      expect(store.read("key2")).to eq("value2")
-      expect(store.read("key3")).to eq("value3")
-      expect(store.read("key1")).to be_nil
+      it "removes expired entries first before evicting others" do
+        store.write("key1", "value1", ttl_seconds: 10)
+        store.write("key2", "value2")
+        store.read("key1")
+
+        Timecop.freeze(Time.now + 20) do
+          store.write("key3", "value3")
+        end
+
+        expect(store.size).to eq(2)
+        expect(store.current_size_bytes).to eq(20)
+        expect(store.read("key2")).to eq("value2")
+        expect(store.read("key3")).to eq("value3")
+        expect(store.read("key1")).to be_nil
+      end
+    end
+
+    describe "using #read_multi & #write_multi" do
+      it "evicts the least recently used entry when the size is exceeded" do
+        store.write_multi({ "key1" => "value1", "key2" => "value2" })
+        store.read_multi("key1")
+        store.write_multi({ "key3" => "value3" })
+
+        expect(store.size).to eq(2)
+        expect(store.current_size_bytes).to eq(20)
+        expect(store.read_multi("key1", "key2", "key3")).to eq({ "key1" => "value1", "key3" => "value3" })
+      end
+
+      it "removes expired entries first before evicting others" do
+        store.write_multi({ "key1" => "value1" }, ttl_seconds: 10)
+        store.write_multi({ "key2" => "value2" })
+        store.read_multi("key1")
+
+        Timecop.freeze(Time.now + 20) do
+          store.write_multi({ "key3" => "value3" })
+        end
+
+        expect(store.size).to eq(2)
+        expect(store.current_size_bytes).to eq(20)
+        expect(store.read_multi("key1", "key2", "key3")).to eq({ "key2" => "value2", "key3" => "value3" })
+      end
     end
 
     it "raises if the serializer does not produce objects that respond to :bytesize" do
       expect do
         described_class.new(max_size_bytes: 20, serializer: identity_serializer)
       end.to raise_error(/respond to :bytesize/)
+    end
+
+    it "updates current_size_bytes when a key is deleted" do
+      expect { store.write("key", "value") }.to change(store, :current_size_bytes).to be > 0
+      expect { store.delete("key") }.to change(store, :current_size_bytes).to(0)
     end
   end
 end


### PR DESCRIPTION
This change implements `#delete`, `#read_multi`, and `#write_multi` to match the interface of ActiveSupport’s `MemoryStore` which will allow us to substitute `omnicache` for `MemoryStore` in the scoped cache.

The tests passed locally and I ran `benchmark` and didn't see any performance regressions.