### PR TITLE
Fix GitHub workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,15 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.0']
+        ruby-version: ['3.2.8']
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
<img width="1384" alt="Screenshot 2025-06-18 at 1 19 29 PM" src="https://github.com/user-attachments/assets/a1ed45e5-a39b-44ad-a86e-b157a0bef4cf" />


I believe the image used by the workflow was deprecated, which caused it to stop running. To fix this, this change uses the recommended image tag for `ruby/setup-ruby` and also bumps the `ruby-version` to match what we're using in `platform`.