### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/lib/omnicache/version.rb
+++ b/lib/omnicache/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniCache
-  VERSION = "0.1.0"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
Bumps the version to `1.0.0`. After this is merged, I'll create a `v1.0.0` tag and cut a release for it.