### PR TITLE
[SMF-1537] Add Datadog tracing to omnicache

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,3 @@ RSpec/MultipleExpectations:
 
 RSpec/ExampleLength:
   Enabled: false
-
-RSpec/NestedGroups:
-  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,3 +32,6 @@ RSpec/MultipleExpectations:
 
 RSpec/ExampleLength:
   Enabled: false
+
+RSpec/NestedGroups:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "bundler"
+gem "datadog", git: "https://github.com/Appboy/dd-trace-rb.git", ref: "v2.15.0-braze"
 gem "rake"
 gem "rspec"
 gem "rubocop"

--- a/lib/omnicache/store.rb
+++ b/lib/omnicache/store.rb
@@ -42,7 +42,7 @@ module OmniCache
     # Reads a value from the store
     # @param key [String | Symbol] The key to read
     def read(key)
-      with_tracing("read") do |_|
+      with_tracing("read") do
         maybe_threadsafe do
           entry = get_entry(key.to_s)
           if entry
@@ -59,7 +59,7 @@ module OmniCache
     # @param keys [Array<String>] The keys to read
     # @return [Hash] A hash mapping the keys provided to the values found
     def read_multi(*keys)
-      with_tracing("read_multi") do |_|
+      with_tracing("read_multi") do
         results = maybe_threadsafe do
           keys.each_with_object({}) do |key, hash|
             entry = get_entry(key.to_s)
@@ -73,7 +73,7 @@ module OmniCache
     end
 
     def write(key, value, ttl_seconds: nil)
-      with_tracing("write") do |_|
+      with_tracing("write") do
         normalized_key = key.to_s
         maybe_threadsafe do
           delete_entry(normalized_key) if @is_lru || value.nil?
@@ -94,7 +94,7 @@ module OmniCache
     # @param ttl_seconds [Integer] TTL for the new entries, in seconds. Uses the default TTL if not provided.
     # @return [Hash] A hash mapping the keys provided to the values written
     def write_multi(entries, ttl_seconds: nil)
-      with_tracing("write_multi") do |_|
+      with_tracing("write_multi") do
         results = maybe_threadsafe do
           written_entries = entries.each_with_object({}) do |(key, value), hash|
             normalized_key = key.to_s
@@ -121,7 +121,7 @@ module OmniCache
     # @yield The block to compute the value if the key is not found
     # @return The cached value or the result of the block if the key was not found
     def fetch(key, options = {})
-      with_tracing("fetch") do |_|
+      with_tracing("fetch") do
         ttl_seconds = nil
 
         if options.key?(:expires_in) && options.key?(:expires_at)
@@ -150,7 +150,7 @@ module OmniCache
     # @param key [String] The key to delete
     # @return [Object|nil] The deleted value if it existed, nil otherwise
     def delete(key)
-      with_tracing("delete") do |_|
+      with_tracing("delete") do
         maybe_threadsafe do
           entry = delete_entry(key.to_s)
           if entry
@@ -161,7 +161,7 @@ module OmniCache
     end
 
     def clear
-      with_tracing("clear") do |_|
+      with_tracing("clear") do
         maybe_threadsafe do
           @data.clear
           @current_size_bytes = 0

--- a/lib/omnicache/store.rb
+++ b/lib/omnicache/store.rb
@@ -42,10 +42,14 @@ module OmniCache
     # Reads a value from the store
     # @param key [String | Symbol] The key to read
     def read(key)
-      maybe_threadsafe do
-        entry = get_entry(key.to_s)
-        if entry
-          @serializer.load(entry.value)
+      with_tracing("read") do |span|
+        normalized_key = key.to_s
+        span&.set_tag("key", normalized_key)
+        maybe_threadsafe do
+          entry = get_entry(normalized_key)
+          if entry
+            @serializer.load(entry.value)
+          end
         end
       end
     end
@@ -57,24 +61,34 @@ module OmniCache
     # @param keys [Array<String>] The keys to read
     # @return [Hash] A hash mapping the keys provided to the values found
     def read_multi(*keys)
-      maybe_threadsafe do
-        keys.each_with_object({}) do |key, results|
-          entry = get_entry(key.to_s)
-          if entry
-            results[key] = @serializer.load(entry.value)
+      with_tracing("read_multi") do |span|
+        normalized_keys = []
+        results = maybe_threadsafe do
+          keys.each_with_object({}) do |key, hash|
+            normalized_key = key.to_s
+            normalized_keys << normalized_key
+            entry = get_entry(normalized_key)
+            if entry
+              hash[key] = @serializer.load(entry.value)
+            end
           end
         end
+        span&.set_tag("keys", normalized_keys.join(","))
+        results
       end
     end
 
     def write(key, value, ttl_seconds: nil)
-      normalized_key = key.to_s
-      maybe_threadsafe do
-        delete_entry(normalized_key) if @is_lru || value.nil?
-        entry = create_entry(normalized_key, value, ttl_seconds)
-        adjust_size if @is_lru
-        if entry
-          value
+      with_tracing("write") do |span|
+        normalized_key = key.to_s
+        span&.set_tag("key", normalized_key)
+        maybe_threadsafe do
+          delete_entry(normalized_key) if @is_lru || value.nil?
+          entry = create_entry(normalized_key, value, ttl_seconds)
+          adjust_size if @is_lru
+          if entry
+            value
+          end
         end
       end
     end
@@ -87,16 +101,22 @@ module OmniCache
     # @param ttl_seconds [Integer] TTL for the new entries, in seconds. Uses the default TTL if not provided.
     # @return [Hash] A hash mapping the keys provided to the values written
     def write_multi(entries, ttl_seconds: nil)
-      maybe_threadsafe do
-        results = entries.each_with_object({}) do |(key, value), hash|
-          normalized_key = key.to_s
-          delete_entry(normalized_key) if @is_lru || value.nil?
-          entry = create_entry(normalized_key, value, ttl_seconds)
-          if entry
-            hash[key] = value
+      with_tracing("write_multi") do |span|
+        normalized_keys = []
+        results = maybe_threadsafe do
+          written_entries = entries.each_with_object({}) do |(key, value), hash|
+            normalized_key = key.to_s
+            normalized_keys << normalized_key
+            delete_entry(normalized_key) if @is_lru || value.nil?
+            entry = create_entry(normalized_key, value, ttl_seconds)
+            if entry
+              hash[key] = value
+            end
           end
+          adjust_size if @is_lru
+          written_entries
         end
-        adjust_size if @is_lru
+        span&.set_tag("keys", normalized_keys.join(","))
         results
       end
     end
@@ -111,45 +131,53 @@ module OmniCache
     # @yield The block to compute the value if the key is not found
     # @return The cached value or the result of the block if the key was not found
     def fetch(key, options = {})
-      ttl_seconds = nil
+      with_tracing("fetch") do |_|
+        ttl_seconds = nil
 
-      if options.key?(:expires_in) && options.key?(:expires_at)
-        raise ArgumentError, "Either :expires_in or :expires_at can be supplied, but not both"
-      end
-
-      if options[:expires_in]
-        unless options[:expires_in].is_a?(Integer)
-          raise ArgumentError, ":expires_in must be an Integer"
+        if options.key?(:expires_in) && options.key?(:expires_at)
+          raise ArgumentError, "Either :expires_in or :expires_at can be supplied, but not both"
         end
 
-        ttl_seconds = options[:expires_in]
-      elsif options[:expires_at]
-        unless options[:expires_at].is_a?(Time)
-          raise ArgumentError, ":expires_at must be a Time"
+        if options[:expires_in]
+          unless options[:expires_in].is_a?(Integer)
+            raise ArgumentError, ":expires_in must be an Integer"
+          end
+
+          ttl_seconds = options[:expires_in]
+        elsif options[:expires_at]
+          unless options[:expires_at].is_a?(Time)
+            raise ArgumentError, ":expires_at must be a Time"
+          end
+
+          ttl_seconds = options[:expires_at] - Time.now
         end
 
-        ttl_seconds = options[:expires_at] - Time.now
+        read(key) || write(key, yield, ttl_seconds: ttl_seconds)
       end
-
-      read(key) || write(key, yield, ttl_seconds: ttl_seconds)
     end
 
     # Deletes a value from the store
     # @param key [String] The key to delete
     # @return [Object|nil] The deleted value if it existed, nil otherwise
     def delete(key)
-      maybe_threadsafe do
-        entry = delete_entry(key.to_s)
-        if entry
-          @serializer.load(entry.value)
+      with_tracing("delete") do |span|
+        normalized_key = key.to_s
+        span&.set_tag("key", normalized_key)
+        maybe_threadsafe do
+          entry = delete_entry(normalized_key)
+          if entry
+            @serializer.load(entry.value)
+          end
         end
       end
     end
 
     def clear
-      maybe_threadsafe do
-        @data.clear
-        @current_size_bytes = 0
+      with_tracing("clear") do |_|
+        maybe_threadsafe do
+          @data.clear
+          @current_size_bytes = 0
+        end
       end
     end
 
@@ -160,6 +188,20 @@ module OmniCache
     alias count size
 
     private
+
+    def with_tracing(resource, &block)
+      if defined?(Datadog::Tracing)
+        Datadog::Tracing.trace(
+          "omnicache",
+          service: "omnicache",
+          resource: resource,
+          type: Datadog::Tracing::Metadata::Ext::AppTypes::TYPE_CACHE,
+          &block
+        )
+      else
+        yield(nil)
+      end
+    end
 
     def check_serializer
       return unless @max_size_bytes

--- a/lib/omnicache/version.rb
+++ b/lib/omnicache/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OmniCache
-  VERSION = "1.0.1"
+  VERSION = "1.0.3"
 end

--- a/spec/omnicache/store_spec.rb
+++ b/spec/omnicache/store_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe OmniCache::Store do
     before do
       allow(Datadog::Tracing).to receive(:tracer).and_return(mock_tracer)
       allow(mock_tracer).to receive(:trace).and_yield(mock_span)
-      allow(mock_span).to receive(:set_tag)
     end
 
     it "can store and retrieve a value" do
@@ -168,7 +167,6 @@ RSpec.describe OmniCache::Store do
         "omnicache",
         hash_including(service: "omnicache", resource: "write")
       )
-      expect(mock_span).to have_received(:set_tag).with("key", "test_key").twice
     end
 
     it "traces read_multi and write_multi" do
@@ -182,7 +180,6 @@ RSpec.describe OmniCache::Store do
         "omnicache",
         hash_including(service: "omnicache", resource: "write_multi")
       )
-      expect(mock_span).to have_received(:set_tag).with("keys", "key1,key2").twice
     end
 
     it "traces fetch" do
@@ -199,7 +196,6 @@ RSpec.describe OmniCache::Store do
         "omnicache",
         hash_including(service: "omnicache", resource: "write")
       )
-      expect(mock_span).to have_received(:set_tag).with("key", "test_key").twice
     end
 
     it "traces delete" do
@@ -208,7 +204,6 @@ RSpec.describe OmniCache::Store do
         "omnicache",
         hash_including(service: "omnicache", resource: "delete")
       )
-      expect(mock_span).to have_received(:set_tag).with("key", "test_key")
     end
 
     it "traces clear" do

--- a/spec/omnicache/store_spec.rb
+++ b/spec/omnicache/store_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe OmniCache::Store do
 
     before do
       allow(Datadog::Tracing).to receive(:tracer).and_return(mock_tracer)
-      allow(mock_tracer).to receive(:trace).and_yield(mock_span)
+      allow(mock_tracer).to receive(:trace).and_yield
     end
 
     it "can store and retrieve a value" do

--- a/spec/omnicache/store_spec.rb
+++ b/spec/omnicache/store_spec.rb
@@ -24,7 +24,13 @@ RSpec.describe OmniCache::Store do
     end
   end
 
+  shared_context "without Datadog" do
+    before { hide_const("Datadog::Tracing") }
+  end
+
   context "with the default configuration" do
+    include_context "without Datadog"
+
     let(:store) { described_class.new }
 
     it "can store and retrieve a value" do
@@ -151,6 +157,8 @@ RSpec.describe OmniCache::Store do
   end
 
   context "with a custom serializer" do
+    include_context "without Datadog"
+
     let(:serializer) { identity_serializer }
     let(:store) { described_class.new(serializer: serializer) }
 
@@ -165,6 +173,8 @@ RSpec.describe OmniCache::Store do
   end
 
   context "with max_entries set" do
+    include_context "without Datadog"
+
     let(:store) { described_class.new(max_entries: 2) }
 
     describe "using #read & #write" do
@@ -222,6 +232,8 @@ RSpec.describe OmniCache::Store do
   end
 
   context "with max_size_bytes set" do
+    include_context "without Datadog"
+
     let(:store) { described_class.new(max_size_bytes: 20, serializer: string_serializer) }
 
     describe "using #read & #write" do
@@ -290,6 +302,97 @@ RSpec.describe OmniCache::Store do
     it "updates current_size_bytes when a key is deleted" do
       expect { store.write("key", "value") }.to change(store, :current_size_bytes).to be > 0
       expect { store.delete("key") }.to change(store, :current_size_bytes).to(0)
+    end
+  end
+
+  context "when Datadog is available" do
+    let(:store) { described_class.new }
+    let(:mock_tracer) { instance_double(Datadog::Tracing::Tracer) }
+    let(:mock_span) { instance_double(Datadog::Tracing::Span) }
+
+    before do
+      allow(Datadog::Tracing).to receive(:tracer).and_return(mock_tracer)
+    end
+
+    it "traces read and write" do
+      allow(mock_tracer).to receive(:trace).with("omnicache",
+                                                 hash_including(service: "omnicache",
+                                                                resource: "read")).and_yield(mock_span)
+      allow(mock_tracer).to receive(:trace).with("omnicache",
+                                                 hash_including(service: "omnicache",
+                                                                resource: "write")).and_yield(mock_span)
+      allow(mock_span).to receive(:set_tag)
+
+      store.write("test_key", "test_value")
+      expect(store.read("test_key")).to eq("test_value")
+      expect(mock_tracer).to have_received(:trace).with("omnicache",
+                                                        hash_including(service: "omnicache", resource: "read"))
+      expect(mock_tracer).to have_received(:trace).with("omnicache",
+                                                        hash_including(service: "omnicache", resource: "write"))
+      expect(mock_span).to have_received(:set_tag).with("key", "test_key").twice
+    end
+
+    it "traces read_multi and write_multi" do
+      allow(mock_tracer).to receive(:trace).with("omnicache",
+                                                 hash_including(service: "omnicache",
+                                                                resource: "write_multi")).and_yield(mock_span)
+      allow(mock_tracer).to receive(:trace).with("omnicache",
+                                                 hash_including(service: "omnicache",
+                                                                resource: "read_multi")).and_yield(mock_span)
+      allow(mock_span).to receive(:set_tag)
+
+      store.write_multi({ "key1" => "value1", "key2" => "value2" })
+      expect(store.read_multi("key1", "key2")).to eq({ "key1" => "value1", "key2" => "value2" })
+      expect(mock_tracer).to have_received(:trace).with("omnicache",
+                                                        hash_including(service: "omnicache", resource: "read_multi"))
+      expect(mock_tracer).to have_received(:trace).with("omnicache",
+                                                        hash_including(service: "omnicache", resource: "write_multi"))
+      expect(mock_span).to have_received(:set_tag).with("keys", "key1,key2").twice
+    end
+
+    it "traces fetch" do
+      allow(mock_tracer).to receive(:trace).with("omnicache",
+                                                 hash_including(service: "omnicache",
+                                                                resource: "fetch")).and_yield(mock_span)
+      allow(mock_tracer).to receive(:trace).with("omnicache",
+                                                 hash_including(service: "omnicache",
+                                                                resource: "read")).and_yield(mock_span)
+      allow(mock_tracer).to receive(:trace).with("omnicache",
+                                                 hash_including(service: "omnicache",
+                                                                resource: "write")).and_yield(mock_span)
+      allow(mock_span).to receive(:set_tag).with(any_args)
+
+      expect(store.fetch("test_key") { 1 + 1 }).to eq(2)
+
+      expect(mock_tracer).to have_received(:trace).with("omnicache",
+                                                        hash_including(service: "omnicache", resource: "fetch"))
+      expect(mock_tracer).to have_received(:trace).with("omnicache",
+                                                        hash_including(service: "omnicache", resource: "read"))
+      expect(mock_tracer).to have_received(:trace).with("omnicache",
+                                                        hash_including(service: "omnicache", resource: "write"))
+      expect(mock_span).to have_received(:set_tag).with("key", "test_key").twice
+    end
+
+    it "traces delete" do
+      allow(mock_tracer).to receive(:trace).with("omnicache",
+                                                 hash_including(service: "omnicache",
+                                                                resource: "delete")).and_yield(mock_span)
+      allow(mock_span).to receive(:set_tag)
+
+      store.delete("test_key")
+
+      expect(mock_tracer).to have_received(:trace).with("omnicache",
+                                                        hash_including(service: "omnicache", resource: "delete"))
+      expect(mock_span).to have_received(:set_tag).with("key", "test_key")
+    end
+
+    it "traces clear" do
+      allow(mock_tracer).to receive(:trace).with("omnicache",
+                                                 hash_including(service: "omnicache",
+                                                                resource: "clear")).and_yield(mock_span)
+      store.clear
+      expect(mock_tracer).to have_received(:trace).with("omnicache",
+                                                        hash_including(service: "omnicache", resource: "clear"))
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require "omnicache"
 require "timecop"
+require "datadog/tracing"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
I noticed that cache operations on `omnicache` weren't showing up on Datadog traces. This change adds tracing to the cache operations so that they can be accounted for.