### PR TITLE
Use ActiveSupport-compatible options hash for write, write_multi, and fetch

### DIFF
--- a/lib/omnicache/active_support_compatibility.rb
+++ b/lib/omnicache/active_support_compatibility.rb
@@ -3,6 +3,17 @@
 module OmniCache
   # Provides ActiveSupport::Cache-compatible methods (read_multi, write_multi, fetch).
   module ActiveSupportCompatibility
+    # Writes a value to the store using ActiveSupport-compatible options.
+    #
+    # @param key [String | Symbol] The key to write
+    # @param value [Object] The value to write
+    # @param options [Hash] Options hash
+    # @option options [Integer] :expires_in Number of seconds until the entry expires
+    # @option options [Time] :expires_at Time at which the entry expires
+    def write(key, value, options = {})
+      super(key, value, ttl_seconds: ttl_from_options(options))
+    end
+
     # Reads multiple values at once from the store
     # @param keys [Array<String>] The keys to read
     # @return [Hash] A hash mapping the keys provided to the values found
@@ -19,9 +30,11 @@ module OmniCache
 
     # Writes multiple values at once to the store
     # @param entries [Hash] A hash mapping keys to values to write
-    # @param ttl_seconds [Integer] TTL for the new entries, in seconds. Uses the default TTL if not provided.
+    # @param options [Hash] Options hash
+    # @option options [Integer] :expires_in Number of seconds until the entries expire
     # @return [Hash] A hash mapping the keys provided to the values written
-    def write_multi(entries, ttl_seconds: nil)
+    def write_multi(entries, options = {})
+      ttl_seconds = ttl_from_options(options)
       maybe_threadsafe do
         written_entries = entries.each_with_object({}) do |(key, value), hash|
           normalized_key = key.to_s
@@ -40,33 +53,31 @@ module OmniCache
     # If it's not in the store, evaluate the given block and write the result to the store.
     #
     # @param key [String] The key to read
-    # @param options [Hash] Optional options for the fetch operation
-    # @option options [Integer] :expires_in The number of seconds until the cache entry expires
-    # @option options [Time] :expires_at The time at which the cache entry expires
+    # @param options [Hash] Options hash
+    # @option options [Integer] :expires_in Number of seconds until the entry expires
+    # @option options [Time] :expires_at Time at which the entry expires
     # @yield The block to compute the value if the key is not found
     # @return The cached value or the result of the block if the key was not found
     def fetch(key, options = {})
-      ttl_seconds = nil
+      read(key) || write(key, yield, options)
+    end
 
+    private
+
+    def ttl_from_options(options)
       if options.key?(:expires_in) && options.key?(:expires_at)
         raise ArgumentError, "Either :expires_in or :expires_at can be supplied, but not both"
       end
 
       if options[:expires_in]
-        unless options[:expires_in].is_a?(Integer)
-          raise ArgumentError, ":expires_in must be an Integer"
-        end
+        raise ArgumentError, ":expires_in must be an Integer" unless options[:expires_in].is_a?(Integer)
 
-        ttl_seconds = options[:expires_in]
+        options[:expires_in]
       elsif options[:expires_at]
-        unless options[:expires_at].is_a?(Time)
-          raise ArgumentError, ":expires_at must be a Time"
-        end
+        raise ArgumentError, ":expires_at must be a Time" unless options[:expires_at].is_a?(Time)
 
-        ttl_seconds = options[:expires_at] - Time.now
+        options[:expires_at] - Time.now
       end
-
-      read(key) || write(key, yield, ttl_seconds: ttl_seconds)
     end
   end
 end

--- a/lib/omnicache/datadog_tracing.rb
+++ b/lib/omnicache/datadog_tracing.rb
@@ -7,7 +7,7 @@ module OmniCache
       with_tracing("read", key: key) { super }
     end
 
-    def write(key, value, ttl_seconds: nil)
+    def write(key, value, *args)
       with_tracing("write", key: key) { super }
     end
 
@@ -15,11 +15,11 @@ module OmniCache
       with_tracing("read_multi", key: keys.join(", ")) { super }
     end
 
-    def write_multi(entries, ttl_seconds: nil)
+    def write_multi(entries, *args)
       with_tracing("write_multi", key: entries.keys.join(", ")) { super }
     end
 
-    def fetch(key, options = {}, &block)
+    def fetch(key, *args, &block)
       with_tracing("fetch", key: key) { super }
     end
 

--- a/spec/omnicache/store_spec.rb
+++ b/spec/omnicache/store_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe OmniCache::Store do
     end
 
     it "does not return expired values" do
-      store.write_multi({ "key2" => "value2" }, ttl_seconds: 10)
+      store.write_multi({ "key2" => "value2" }, expires_in: 10)
       Timecop.freeze(Time.now + 20) do
         expect(store.read_multi("key2")).to eq({})
       end
@@ -135,6 +135,39 @@ RSpec.describe OmniCache::Store do
       expect(store.read("key")).to eq(2)
     end
 
+    it "uses the expires_in option when using write" do
+      store.write("key", "value", expires_in: 10)
+      expect(store.read("key")).to eq("value")
+      Timecop.freeze(Time.now + 20) do
+        expect(store.read("key")).to be_nil
+      end
+    end
+
+    it "raises an error if expires_in is not an Integer when using write" do
+      expect do
+        store.write("key", "value", expires_in: "1")
+      end.to raise_error(ArgumentError, ":expires_in must be an Integer")
+    end
+
+    it "uses the expires_at option when using write" do
+      store.write("key", "value", expires_at: Time.now + 10)
+      expect(store.read("key")).to eq("value")
+      Timecop.freeze(Time.now + 20) do
+        expect(store.read("key")).to be_nil
+      end
+    end
+
+    it "raises an error if expires_at is not a Time when using write" do
+      expect { store.write("key", "value", expires_at: 10) }.to raise_error(ArgumentError, ":expires_at must be a Time")
+    end
+
+    it "raises an error if both expires_in and expires_at are provided when using write" do
+      expect { store.write("key", "value", expires_in: 10, expires_at: Time.now + 20) }.to raise_error(
+        ArgumentError,
+        "Either :expires_in or :expires_at can be supplied, but not both"
+      )
+    end
+
     it "uses the expires_in option when using fetch" do
       store.fetch("key", expires_in: 10) { "value" }
       expect(store.read("key")).to eq("value")
@@ -143,27 +176,12 @@ RSpec.describe OmniCache::Store do
       end
     end
 
-    it "raises an error if expires_in is not an Integer when using fetch" do
-      expect { store.fetch("key", expires_in: "1") }.to raise_error(ArgumentError, ":expires_in must be an Integer")
-    end
-
     it "uses the expires_at option when using fetch" do
       store.fetch("key", expires_at: Time.now + 10) { "value" }
       expect(store.read("key")).to eq("value")
       Timecop.freeze(Time.now + 20) do
         expect(store.read("key")).to be_nil
       end
-    end
-
-    it "raises an error if expires_at is not a Time when using fetch" do
-      expect { store.fetch("key", expires_at: 10) }.to raise_error(ArgumentError, ":expires_at must be a Time")
-    end
-
-    it "raises an error if both expires_in and expires_at are provided when using fetch" do
-      expect { store.fetch("key", expires_in: 10, expires_at: Time.now + 20) }.to raise_error(
-        ArgumentError,
-        "Either :expires_in or :expires_at can be supplied, but not both"
-      )
     end
   end
 
@@ -299,7 +317,7 @@ RSpec.describe OmniCache::Store do
       end
 
       it "removes expired entries first before evicting others" do
-        store.write_multi({ "key1" => "value1" }, ttl_seconds: 10)
+        store.write_multi({ "key1" => "value1" }, expires_in: 10)
         store.write_multi({ "key2" => "value2" })
         store.read_multi("key1")
 
@@ -363,7 +381,7 @@ RSpec.describe OmniCache::Store do
       end
 
       it "removes expired entries first before evicting others" do
-        store.write_multi({ "key1" => "value1" }, ttl_seconds: 10)
+        store.write_multi({ "key1" => "value1" }, expires_in: 10)
         store.write_multi({ "key2" => "value2" })
         store.read_multi("key1")
 


### PR DESCRIPTION
ActiveSupport::Cache uses `expires_in:` and `expires_at:` keyword options rather than `ttl_seconds:`. This updates the ActiveSupportCompatibility module to match that interface:

    - Override `write` to accept `**options` (with `expires_in:` / `expires_at:`)
      and translate to `ttl_seconds:` for the base Store.
    - Change `write_multi` from `ttl_seconds:` to `**options` with the same
      translation.
    - Simplify `fetch` to just forward options to `write`, since TTL conversion
      logic now lives in `write` via a shared `ttl_from_options` helper.
    - Update DatadogTracing signatures to `**options` so they forward
      transparently regardless of which modules are active.

The base Store retains its `ttl_seconds:` API unchanged.